### PR TITLE
Remove Lua filter references from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A forkable template for publishing a résumé/CV with Markdown, BibTeX, and Pandoc. The repository keeps a generic example on `main` while GitHub Pages serves your personalized CV from the `gh-pages` branch root (`index.html`, `cv.css`).
 
 ## Branch Strategy
-- **`main`** – holds the generic example plus reusable tooling (`templates/`, `css/`, `csl/`, `filters/`, workflows). Forks should update files here before syncing downstream.
+- **`main`** – holds the generic example plus reusable tooling (`templates/`, `css/`, `csl/`, workflows). Forks should update files here before syncing downstream.
 - **`gh-pages`** – hosts the rendered site. Every push to `main` triggers a workflow that syncs all changes into `gh-pages`, except for `cv.md` and `publications.bib`. Those two files stay personalized on `gh-pages` and are never overwritten by automation.
 
 ## Workflow Overview
@@ -13,7 +13,7 @@ Workflow file: `.github/workflows/build.yaml`
    - Checkout both branches using a worktree.
    - Merge latest `main` files into `gh-pages`, skipping conflicts in `cv.md` and `publications.bib`.
    - If any other file conflicts, the workflow fails with an actionable error (requires manual resolution).
-   - Render `cv.md` (from `gh-pages`) to `index.html` using Pandoc with the custom template, CSS, CSL, and Lua filter.
+   - Render `cv.md` (from `gh-pages`) to `index.html` using Pandoc with the custom template, CSS, and CSL resources.
    - Copy `css/cv.css` to the branch root as `cv.css`, ensure `.nojekyll` exists, commit, and push to `gh-pages`.
 2. **On `gh-pages` pushes**
    - Re-run the render step so direct edits to `cv.md`/`publications.bib` publish immediately.
@@ -25,7 +25,7 @@ Workflow file: `.github/workflows/build.yaml`
    - `cv.md` (front matter + Markdown content; ensure publications block includes `::: {#refs}`).
    - `publications.bib` (add/update BibTeX entries).
 3. Commit and push to `gh-pages`. The workflow renders fresh `index.html` and `cv.css` in the branch root. GitHub Pages should be configured to serve the `gh-pages` branch.
-4. Update shared resources on `main` when you want to adjust styling or behavior (template, CSS, workflows, filters, CSL, instructions). Push to `main` to propagate changes to `gh-pages` automatically.
+4. Update shared resources on `main` when you want to adjust styling or behavior (template, CSS, workflows, CSL, instructions). Push to `main` to propagate changes to `gh-pages` automatically.
 
 ## Local Build (Optional)
 ```bash
@@ -38,7 +38,6 @@ pandoc cv.md \
   --csl=csl/chicago-author-date-date-desc.csl \
   --template=templates/cv.html \
   --css=cv.css \
-  --lua-filter=filters/refs-list.lua \
   --output index.html
 cp css/cv.css ./cv.css
 touch .nojekyll
@@ -50,7 +49,6 @@ Preview `index.html` locally before pushing.
 - **Stylesheet (`css/cv.css`)** – Control typography, spacing, colors, print behavior (includes `[Print]` button styling).
 - **Metadata** – Extend front matter in `cv.md` (e.g., `site_url`, custom section toggles) and reference via `$if(...)$` blocks in the template.
 - **CSL (`csl/chicago-author-date-date-desc.csl`)** – Modify citation style.
-- **Lua Filter (`filters/refs-list.lua`)** – Tweak bibliography structure (e.g., ordered vs unordered list).
 
 ## Sync Conflict Resolution
 If the workflow fails with `Merge conflict syncing main→gh-pages`:

--- a/codex/README.md
+++ b/codex/README.md
@@ -31,6 +31,7 @@ Provide an example single-source CV website from Markdown (`cv.md`) and a BibTeX
 ## Constraints
 - Keep build under ~2 minutes on GitHub-hosted runners.
 - Avoid dependencies beyond stock `pandoc` (with built-in citeproc).
+- Treat custom Lua filters as out of scope for this project.
 - Pages configured to serve from a gh-pages branch in the `/` directory. Ensure `/.nojekyll` exists.
 
 ## Local Build (optional)


### PR DESCRIPTION
## Summary
- note that Lua filters are out of scope in the codex constraints
- update the main README to remove Lua filter references from workflows, build steps, and customization guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d9dae3abe48324922b1472a6cf0307